### PR TITLE
Bot label `~capi` to auto assign capi folks

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -258,6 +258,16 @@
 	},
 	{
 		"type": "label",
+		"name": "~capi",
+		"addLabel": "capi",
+		"removeLabel": "~capi",
+		"assign": [
+			"samvantran",
+			"thispaul"
+		]
+	},
+	{
+		"type": "label",
 		"name": "notebook",
 		"assign": [
 			"rebornix"


### PR DESCRIPTION
cc @isidorn per our slack discussion for auto assigning @samvantran and @thispaul for capi related issues. 

Currently this isn't bot driven, but I'll be getting that set up today. The scope of what this will cover is listed in the CAPI section(s) here: https://github.com/microsoft/vscode-copilot/wiki/Copilot-Inbox-Tracker

In case people don't have access to that page:

--- 

### Areas owned by CAPI (use label `~capi` and they will be auto assigned) 

▶︎ Apply this label only when the issue’s root cause or primary focus is on Copilot’s back-end or service-side behavior rather than VS Code’s UI or interaction layer

▶︎ Label with `~capi` if the report concerns...

- Service availability or latency (slow completions, time-outs, network errors)
- Speed / performance of generated answers
- Billing & quota (charges, usage limits, subscription status)
- Service-side errors or outages (HTTP error codes, responses not returned)
- Responsible AI / compliance topics (content filtering)

▶︎ Do NOT apply if the issue is about...

- Editor UX / UI problems
- Copilot Agent / inline chat features or workflows
- Prompt panels, suggestions UI, or any interactive chat experience inside VS Code

▶︎ If you spot a pattern of CAPI issues...

- Reach out to the CAPI team on [Slack](https://github-grid.enterprise.slack.com/archives/C04U1GDEECE)<br/>
- They will appreciate request ids (`~info-needed` will comment with a pointer to the copilot issues guidelines), and you can eventually make them an issue at https://github.com/github/copilot/issues<br/>