### PR TITLE
Point issues at vscode

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,12 +3,15 @@ contact_links:
   - name: Questions
     url: https://github.com/orgs/community/discussions/categories/copilot
     about: Please ask and answer questions about GitHub Copilot here
+  - name: Copilot Chat Issues
+    url: https://github.com/microsoft/vscode/issues/new?labels=chat-oss-issue
+    about: Please file issues related to Copilot Chat in the VS Code repository.
   - name: Responsible AI Service response blocking
-    url: https://github.com/microsoft/vscode-copilot-release/issues/2625
+    url: https://github.com/microsoft/vscode/issues/253130
     about: See meta-issue for information on RAI response blocking.
   - name: Request Rate Limiting
-    url: https://github.com/microsoft/vscode-copilot-release/issues/2627
+    url: https://github.com/microsoft/vscode/issues/253124
     about: See meta-issue for scenarios where chat requests are blocked due to rate limiting.
   - name: Public Code Matching
-    url: https://github.com/microsoft/vscode-copilot-release/issues/2626
-    about: Learn how to enable/disable public code matching in responses via your organizational settings. 
+    url: https://github.com/microsoft/vscode/issues/253129
+    about: Learn how to enable/disable public code matching in responses via your organizational settings.


### PR DESCRIPTION
This will prevent filing new issues and deprecate the repo, without having to disable issues completely (and therefore get rid of the issue tab). 

Direct issuesto `vscode` while transferring to OSS.

Archiving issues will not allow them to be transferred, so is too extreme of a solution.